### PR TITLE
fixed show alert for loading model in ParametersScreen on click save changes button

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
@@ -66,18 +66,14 @@ fun ParametersScreen(viewModel: MainViewModel) {
             ),
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
         ) {
+            if (viewModel.showAlert) {
+                LoadingModal(viewModel)
+            }
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize() // Fill the card's space
                     .padding(15.dp)
             ) {
-                item {
-                    if (viewModel.showAlert) {
-                        LoadingModal(viewModel)
-                    }
-                }
-
-
                 item {
                     SettingSection(
                         title = "Thread Selection",

--- a/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
@@ -196,13 +196,18 @@ fun ParametersScreen(viewModel: MainViewModel) {
                     pressedElevation = 3.dp
                 ),
                 onClick = {
-                    viewModel.user_thread = 0f
-                    viewModel.temp = 0f
-                    viewModel.topK = 0
-                    viewModel.topP = 0f
-                    viewModel.currentDownloadable?.destination?.path?.let {
-                        viewModel.load(it, viewModel.user_thread.toInt())
-                        Toast.makeText(context, "Settings reset to default", Toast.LENGTH_SHORT).show()
+                    if(viewModel.loadedModelName.value == "") {
+                        Toast.makeText(context, "Load A Model First", Toast.LENGTH_SHORT).show()
+                    }else {
+                        viewModel.user_thread = 0f
+                        viewModel.temp = 0f
+                        viewModel.topK = 0
+                        viewModel.topP = 0f
+                        viewModel.currentDownloadable?.destination?.path?.let {
+                            viewModel.load(it, viewModel.user_thread.toInt())
+                            Toast.makeText(context, "Settings reset to default", Toast.LENGTH_SHORT)
+                                .show()
+                        }
                     }
                 }
             ) {


### PR DESCRIPTION
1. Problem: Loading a random model when no current active model exists.
Fix: Ensured the toast message is shown on the "Reset Default" button click in the Parameters screen if there is no current active model.
2. Problem: Alert ("Loading model") not displayed when saving parameter changes.
Fix: Resolved the loading state issue triggered by the "Save Changes" button click in the Parameters screen.